### PR TITLE
test: check default preset is balanced

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,8 +17,13 @@ class TestConfig:
         """Test default model preset is balanced"""
         with patch.dict(os.environ, {}, clear=True):
             config = Config()
+            # Ensure the default preset is balanced
+            assert config.CURRENT_PRESET == "balanced"
+
             llm_config = config.get_current_llm_config()
-            assert llm_config is not None
+            # Retrieved model should match the balanced preset
+            balanced_model = config.MODEL_PRESETS["balanced"]["llm"].name
+            assert llm_config.name == balanced_model
             
     def test_custom_model_preset(self):
         """Test setting custom model preset"""


### PR DESCRIPTION
## Summary
- verify Config defaults to the balanced model preset

## Testing
- `pytest tests/test_config.py::TestConfig::test_default_model_preset -q`

------
https://chatgpt.com/codex/tasks/task_e_6896b626130c832fac373ff0896d6225