### PR TITLE
Handle empty query in keyword search

### DIFF
--- a/src/vector_store/store.py
+++ b/src/vector_store/store.py
@@ -321,6 +321,9 @@ class EnhancedVectorStore:
             
             # Simple keyword matching
             query_words = set(query.lower().split())
+            if not query_words:
+                return []
+
             scored_docs = []
             
             for i, doc_content in enumerate(results['documents']):


### PR DESCRIPTION
## Summary
- Avoid division by zero in keyword search by returning empty results when no query words are provided

## Testing
- `pytest tests/test_vector_store.py::TestEnhancedVectorStore::test_similarity_search -q` *(fails: requests.exceptions.ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_6896b61fdc94832fa52883941f03cae4