### PR TITLE
docs: clarify Testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The application will be available at `http://localhost:8501`
 
 ## Testing
 
-The application includes comprehensive functionality testing through the web interface. You can test the system by:
+The application includes comprehensive functionality testing through the web interface. You can test the system by uploading documents and asking questions.
 ## Development
 
 ### Testing the Application


### PR DESCRIPTION
## Summary
- clarify README's Testing section by replacing trailing colon with complete sentence

## Testing
- `pytest -q` *(fails: ProxyError to huggingface and openaipublic blob storage)*

------
https://chatgpt.com/codex/tasks/task_e_6896b61d8454832fa9a458e6d2822057