### PR TITLE
docs: update project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,12 @@ langchain-rag-app/
 ├── config/                      # Configuration files
 │   ├── __init__.py
 │   └── setup.py                 # Setup script
-├── docs/                        # Documentation
-├── examples/                    # Example files
-├── main.py                      # Main entry point
+├── scripts/                     # Helper and startup scripts
+│   ├── main.py                  # CLI entry point
+│   ├── run.py                   # Launcher
+│   ├── run_web.py               # Launch web app
+│   ├── run.sh                   # Unix launcher
+│   └── run.bat                  # Windows launcher
 ├── requirements.txt             # Python dependencies
 ├── .env                         # Environment variables (create this)
 ├── .gitignore                   # Git ignore rules


### PR DESCRIPTION
## Summary
- align README project structure with repo

## Testing
- `pytest` *(fails: requests.exceptions.ProxyError, HTTPSConnectionPool(host='huggingface.co', port=443): Max retries exceeded with url: /sentence-transformers/all-MiniLM-L6-v2/resolve/main/adapter_config.json (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*

------
https://chatgpt.com/codex/tasks/task_e_6896b61a3ca8832f8a0b0e19117e1719